### PR TITLE
fix(fluent-bit): resolve backpressure log loss by upgrading to v3.2.10 and tuning pipeline

### DIFF
--- a/kubernetes/helm_charts/logging/fluent-bit/templates/configMap.yaml
+++ b/kubernetes/helm_charts/logging/fluent-bit/templates/configMap.yaml
@@ -33,10 +33,10 @@ data:
         K8S-Logging.Exclude On
 
     [FILTER]
-        # Discard all health debug and info logs
+        # Discard health check, debug, and info logs
         Name grep
         Match kube.*
-        exclude message /^.*(?:debug|info|GET (\/service)?\/health).*$
+        Exclude message (?:debug|info|GET (?:\/service)?\/health)
 
     [FILTER]
         Name          nest
@@ -61,7 +61,7 @@ data:
 
   fluent-bit.conf: |
     [SERVICE]
-        Flush         1
+        Flush         5
         Log_Level     WARNING
         Daemon        off
         Parsers_File  parsers.conf
@@ -71,9 +71,13 @@ data:
         storage.path              /mnt/log/flb-storage/
         storage.sync              normal
         storage.checksum          off
-        storage.backlog.mem_limit 120M
-        # How many chunks from file system, which is in que to flush to es, has to be in memory(warm)
-        storage.max_chunks_up 50
+        storage.backlog.mem_limit 256M
+        # Allow 128 warm chunks in memory (was 50 — caused 'no available chunk')
+        storage.max_chunks_up     128
+        # Expose chunk metrics to Prometheus
+        storage.metrics           on
+        # Auto-delete corrupt chunks that block the pipeline
+        storage.delete_irrecoverable_chunks on
 
     @INCLUDE input-kubernetes.conf
     @INCLUDE filter-kubernetes.conf
@@ -83,22 +87,20 @@ data:
         Name              tail
         Tag               kube.*
         Path              /var/log/containers/*.log
+        # Exclude fluent-bit own logs to avoid recursion
+        Exclude_Path      /var/log/containers/fluent-bit*
         Parser            cri
         DB                /mnt/log/flb_kube.db
-        Mem_Buf_Limit     120MB
-        # Set the initial buffer size to read files data.
-        # This value is used too to increase buffer size.
-        Buffer_Chunk_Size 256k
-        # Set the limit of the buffer size per monitored file.
-        # When a buffer needs to be increased (e.g: very long lines),
-        # this value is used to restrict how much the memory buffer can grow.
-        # If reading a file exceed this limit, the file is removed from the monitored file list
-        Buffer_Max_Size   512k
+        # Mem_Buf_Limit has no effect with storage.type filesystem
+        # Backpressure controlled by storage.max_chunks_up instead
+        Buffer_Chunk_Size 512k
+        Buffer_Max_Size   2M
         Skip_Long_Lines   On
-        Refresh_Interval  1
-        storage.type  filesystem
+        # Reduce scan frequency (was 1s — unnecessary CPU overhead)
+        Refresh_Interval  5
+        storage.type      filesystem
         # Ignore older logs of 30m
-        Ignore_Older       30m
+        Ignore_Older      30m
   output-elasticsearch.conf: |
     [OUTPUT]
         Name            es
@@ -107,20 +109,26 @@ data:
         Port            ${FLUENT_ELASTICSEARCH_PORT}
         Logstash_Format On
         Replace_Dots    On
-        Retry_Limit     10
         Type            _doc
-        # Networking Setup
+        # Parallel flush workers (was 1 — the main bottleneck)
+        Workers         4
+        # Compress bulk payloads — ~70% bandwidth reduction
+        Compress        gzip
+        # Prevent duplicate records on retry
+        Generate_ID     On
+        # Restore v1.6 write behavior for ES 7.x compatibility
+        Write_Operation index
+        # Unlimited retries — filesystem storage handles backpressure via LRU
+        Retry_Limit     False
+        # Log ES errors for debugging
+        Trace_Error     On
+        # Networking
         net.connect_timeout         10
-        # net.source_address          127.0.0.1
         net.keepalive               on
         net.keepalive_idle_timeout  100
-        net.keepalive_max_recycle 200
-        #
-        # Limit the maximum number of Chunks in the filesystem for the current output logical destination.
-        # After this LRU will kick in; that means LeastRecentlyUsed will get deleted
-        # 1 chunk =~ 2MB
-        # This config has some issues; see https://github.com/fluent/fluent-bit/issues/2688
-        storage.total_limit_size 20G
+        net.keepalive_max_recycle   2000
+        # Limit filesystem buffer per output (was 20G — risked filling node disk)
+        storage.total_limit_size    5G
   parsers.conf: |
     [PARSER]
         Name   apache

--- a/kubernetes/helm_charts/logging/fluent-bit/templates/daemonset.yaml
+++ b/kubernetes/helm_charts/logging/fluent-bit/templates/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
 {{- include "fluent-bit.labels" . | nindent 8 }}
       annotations:
         fluent-bitRolloutID: {{ randAlphaNum 5 | quote }} # Restart fluent-bit after every deployment
-        fleuntbit.io/exlude: "true"
+        fluentbit.io/exclude: "true"
     spec:
 {{- if .Values.imagepullsecrets }}
       imagePullSecrets:
@@ -38,10 +38,31 @@ spec:
       containers:
       - name: fluent-bit
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 2020
           name: http-metrics
+        resources:
+          requests:
+            cpu: {{ .Values.resources.requests.cpu | default "200m" | quote }}
+            memory: {{ .Values.resources.requests.memory | default "256Mi" | quote }}
+          limits:
+            cpu: {{ .Values.resources.limits.cpu | default "1" | quote }}
+            memory: {{ .Values.resources.limits.memory | default "512Mi" | quote }}
+        livenessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: 2020
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /api/v1/health
+            port: 2020
+          initialDelaySeconds: 10
+          periodSeconds: 15
+          timeoutSeconds: 5
         env:
         - name: FLUENT_ELASTICSEARCH_HOST
           value: "{{ .Values.es_host }}"
@@ -57,7 +78,7 @@ spec:
           readOnly: true
         - name: fluent-bit-config
           mountPath: /fluent-bit/etc/
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 60
       volumes:
       - name: datapath
         hostPath:

--- a/kubernetes/helm_charts/logging/fluent-bit/values.yaml
+++ b/kubernetes/helm_charts/logging/fluent-bit/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: fluent/fluent-bit
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "1.6.10"
+  tag: "3.2.10"
 
 es_host: log-es.logging.svc.cluster.local
 es_port: 9200
@@ -65,17 +65,13 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  limits:
+    cpu: "1"
+    memory: 512Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
…0 and tuning pipeline

Fluent Bit pods hitting 'no available chunk' and 'no enough space in filesystem' errors — logs being silently dropped under high volume because single output worker cannot flush to ES fast enough.

- Upgrade image from v1.6.10 to v3.2.10 (fixes known chunk handling bugs)
- Add 4 parallel output workers + gzip compression to eliminate flush bottleneck
- Increase storage.max_chunks_up 50→128 for more buffer headroom
- Increase Flush interval 1s→5s to reduce ES bulk request storm
- Add Generate_ID + Write_Operation index for ES 7.x compat and dedup
- Fix grep regex that caused catastrophic backtracking on long lines
- Add resource requests/limits to prevent OOM and node starvation
- Add liveness/readiness probes to auto-recover hung pods
- Increase terminationGracePeriodSeconds 10→60 to allow buffer flush on shutdown
- Reduce storage.total_limit_size 20G→5G to prevent node disk exhaustion
- Add storage.delete_irrecoverable_chunks to unblock corrupt chunk scenarios
- Fix annotation typo fluentbit.io/exclude