### PR TITLE
Changes post loadtest

### DIFF
--- a/ansible/roles/keycloak-deploy/templates/standalone-ha.xml
+++ b/ansible/roles/keycloak-deploy/templates/standalone-ha.xml
@@ -247,12 +247,24 @@
                 <local-cache name="users">
                     <object-memory size="10000"/>
                 </local-cache>
-                <distributed-cache name="sessions" owners="2"/>
-                <distributed-cache name="authenticationSessions" owners="2"/>
-		<distributed-cache name="offlineSessions" owners="2"/>
-                <distributed-cache name="clientSessions" owners="2"/>
-		<distributed-cache name="offlineClientSessions" owners="2"/>
-                <distributed-cache name="loginFailures" owners="2"/>
+                <distributed-cache name="sessions" owners="2">
+                    {% if keycloak_sessions_cache_object_size is defined %}<object-memory size="{{ keycloak_sessions_cache_object_size }}"/>{% endif %}
+                </distributed-cache>
+                <distributed-cache name="authenticationSessions" owners="2">
+                    {% if keycloak_authentication_sessions_cache_object_size is defined %}<object-memory size="{{ keycloak_authentication_sessions_cache_object_size }}"/>{% endif %}
+                </distributed-cache>
+                <distributed-cache name="offlineSessions" owners="2">
+                    {% if keycloak_offline_sessions_cache_object_size is defined %}<object-memory size="{{ keycloak_offline_sessions_cache_object_size }}"/>{% endif %}
+                </distributed-cache>
+                <distributed-cache name="clientSessions" owners="2">
+                    {% if keycloak_client_sessions_cache_object_size is defined %}<object-memory size="{{ keycloak_client_sessions_cache_object_size }}"/>{% endif %}
+                </distributed-cache>
+                <distributed-cache name="offlineClientSessions" owners="2">
+                    {% if keycloak_offline_client_sessions_cache_object_size is defined %}<object-memory size="{{ keycloak_offline_client_sessions_cache_object_size }}"/>{% endif %}
+                </distributed-cache>
+                <distributed-cache name="loginFailures" owners="2">
+                    {% if keycloak_login_failures_cache_object_size is defined %}<object-memory size="{{ keycloak_login_failures_cache_object_size }}"/>{% endif %}
+                </distributed-cache>
                 <local-cache name="authorization">
                     <object-memory size="10000"/>
                 </local-cache>

--- a/ansible/roles/keycloak-deploy/templates/standalone-ha.xml
+++ b/ansible/roles/keycloak-deploy/templates/standalone-ha.xml
@@ -563,7 +563,7 @@
             </security-domains>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:transactions:5.0">
-	    <core-environment node-identifier="{{ansible_default_ipv4.address}}">
+	    <core-environment node-identifier="keycloak-{{ ansible_hostname | regex_replace('[^A-Za-z0-9_-]', '-') }}">
                 <process-id>
                     <uuid/>
                 </process-id>

--- a/ansible/roles/keycloak-deploy/templates/standalone.conf.j2
+++ b/ansible/roles/keycloak-deploy/templates/standalone.conf.j2
@@ -72,5 +72,5 @@ fi
 # when you get "epoll_create function not implemented" message in dmesg output
 #JAVA_OPTS="$JAVA_OPTS -Djava.nio.channels.spi.SelectorProvider=sun.nio.ch.PollSelectorProvider"
 
-# Advertise node ip
-JAVA_OPTS="$JAVA_OPTS -Djboss.node.name={{ansible_host}}"
+# Advertise node name
+JAVA_OPTS="$JAVA_OPTS -Djboss.node.name={{ ansible_hostname }}"

--- a/kubernetes/ansible/roles/deploy-player/tasks/main.yml
+++ b/kubernetes/ansible/roles/deploy-player/tasks/main.yml
@@ -55,7 +55,7 @@
   when: release_name == "player"
 
 - name: helm install and upgrade
-  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("10m")}} {{ release_name }} {{ chart_path }} -n {{namespace}}
+  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("20m")}} {{ release_name }} {{ chart_path }} -n {{namespace}}
 
 - name: Clean up keys
   include_role:

--- a/kubernetes/ansible/roles/helm-daemonset/tasks/main.yml
+++ b/kubernetes/ansible/roles/helm-daemonset/tasks/main.yml
@@ -15,7 +15,7 @@
     dest: "{{ chart_path }}/values.yaml"
 
 - name: helm install
-  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("10m")}} {{ release_name }} {{ chart_path }} -n {{namespace}}
+  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("20m")}} {{ release_name }} {{ chart_path }} -n {{namespace}}
 
 - name: Get the deployment rollout status
   shell: "kubectl get daemonsets -A | grep -i {{ release_name }} | awk -F' ' '{if ($3 ~ $6){exit 0} else {exit 1}}'"

--- a/kubernetes/ansible/roles/helm-deploy/tasks/main.yml
+++ b/kubernetes/ansible/roles/helm-deploy/tasks/main.yml
@@ -91,7 +91,7 @@
   when: vars[release_name + '_opa_enabled'] is defined and vars[release_name + '_opa_enabled']
 
 - name: helm install
-  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("10m")}} {{ release_name }} {{ chart_path }} -n {{namespace}}
+  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("20m")}} {{ release_name }} {{ chart_path }} -n {{namespace}}
 
 - name: Clean up keys
   include_role:

--- a/kubernetes/ansible/roles/logging/tasks/main.yml
+++ b/kubernetes/ansible/roles/logging/tasks/main.yml
@@ -5,4 +5,4 @@
     dest: "/tmp/{{ release_name }}.yaml"
 
 - name: helm install
-  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("10m")}} --force {{ release_name }} {{ chart_path }} -n logging -f /tmp/{{ release_name }}.yaml
+  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("20m")}} --force {{ release_name }} {{ chart_path }} -n logging -f /tmp/{{ release_name }}.yaml

--- a/kubernetes/ansible/roles/proxy/tasks/main.yml
+++ b/kubernetes/ansible/roles/proxy/tasks/main.yml
@@ -45,5 +45,5 @@
     dest: "{{ chart_path }}/values.yaml"
 
 - name: helm install
-  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("10m")}} --force {{ release_name }} {{ chart_path }} -n {{namespace}}
+  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("20m")}} --force {{ release_name }} {{ chart_path }} -n {{namespace}}
 

--- a/kubernetes/ansible/roles/sunbird-monitoring/tasks/main.yml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/tasks/main.yml
@@ -9,11 +9,11 @@
     - always
 
 - name: Creating sunbird monitoring stack
-  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("10m")}} {{ item }} {{chart_path}}/{{ item }} --namespace monitoring -f /tmp/{{ item }}.yaml
+  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("20m")}} {{ item }} {{chart_path}}/{{ item }} --namespace monitoring -f /tmp/{{ item }}.yaml
   with_items: "{{ monitoring_stack + monitoring_stack_additional_charts }}"
 
 - name: Updating external monitoring targets
-  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("10m")}} {{ item }} {{chart_path}}/{{ item }} --namespace monitoring -f /tmp/{{ item }}.yaml
+  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("20m")}} {{ item }} {{chart_path}}/{{ item }} --namespace monitoring -f /tmp/{{ item }}.yaml
   with_items: "additional-scrape-configs"
   tags:
     - scrapeconfigs

--- a/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
+++ b/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
@@ -1428,6 +1428,32 @@ proxyconfig: |-
       client_max_body_size 1126M;
     }
 
+    location ~ /apis/v1/form/read {
+      # Enabling caching
+      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache framework_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_methods GET HEAD POST;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/apis/(.*) /$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_set_header X-Request-ID $sb_request_id;
+      proxy_pass http://ui-proxies:3003;
+    }
+
     location /apis/ {
       # if ($request_method = OPTIONS ) {
        #       add_header Access-Control-Allow-Origin "*" ;
@@ -2673,6 +2699,32 @@ proxyconfig: |-
       proxy_set_header X-Request-ID $sb_request_id;
       proxy_pass http://kong;
     }
+    location ~ /apis/v1/form/read {
+      # Enabling caching
+      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache framework_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_methods GET HEAD POST;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/apis/(.*) /$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_set_header X-Request-ID $sb_request_id;
+      proxy_pass http://ui-proxies:3003;
+    }
+
     location /apis/ {
       if ($request_method = OPTIONS ) {
               add_header Access-Control-Allow-Origin "*" ;
@@ -3630,6 +3682,32 @@ proxyconfig: |-
       proxy_set_header X-Request-ID $sb_request_id;
       proxy_pass http://kong;
     }
+    location ~ /apis/v1/form/read {
+      # Enabling caching
+      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache framework_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_methods GET HEAD POST;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/apis/(.*) /$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_set_header X-Request-ID $sb_request_id;
+      proxy_pass http://ui-proxies:3003;
+    }
+
     location /apis/ {
       if ($request_method = OPTIONS ) {
               add_header Access-Control-Allow-Origin "*" ;
@@ -5198,6 +5276,32 @@ proxyconfig: |-
       client_max_body_size 1226M;
     }
 
+    location ~ /apis/v1/form/read {
+      # Enabling caching
+      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache framework_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_methods GET HEAD POST;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/apis/(.*) /$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_set_header X-Request-ID $sb_request_id;
+      proxy_pass http://ui-proxies:3003;
+    }
+
     location /apis/ {
       # if ($request_method = OPTIONS ) {
        #       add_header Access-Control-Allow-Origin "*" ;
@@ -6643,6 +6747,32 @@ proxyconfig: |-
       client_max_body_size 1226M;
     }
 
+    location ~ /apis/v1/form/read {
+      # Enabling caching
+      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache framework_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_methods GET HEAD POST;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/apis/(.*) /$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_set_header X-Request-ID $sb_request_id;
+      proxy_pass http://ui-proxies:3003;
+    }
+
     location /apis/ {
       # if ($request_method = OPTIONS ) {
        #       add_header Access-Control-Allow-Origin "*" ;
@@ -7646,6 +7776,32 @@ proxyconfig: |-
       proxy_set_header X-Request-ID $sb_request_id;
       proxy_pass http://kong;
     }
+    location ~ /apis/v1/form/read {
+      # Enabling caching
+      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache framework_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_methods GET HEAD POST;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/apis/(.*) /$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_set_header X-Request-ID $sb_request_id;
+      proxy_pass http://ui-proxies:3003;
+    }
+
     location /apis/ {
       if ($request_method = OPTIONS ) {
               add_header Access-Control-Allow-Origin "*" ;
@@ -8591,6 +8747,32 @@ proxyconfig: |-
       proxy_set_header X-Request-ID $sb_request_id;
       proxy_pass http://kong;
     }
+    location ~ /apis/v1/form/read {
+      # Enabling caching
+      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache framework_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_methods GET HEAD POST;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/apis/(.*) /$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_set_header X-Request-ID $sb_request_id;
+      proxy_pass http://ui-proxies:3003;
+    }
+
     location /apis/ {
       if ($request_method = OPTIONS ) {
               add_header Access-Control-Allow-Origin "*" ;

--- a/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
+++ b/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
@@ -538,7 +538,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -565,7 +565,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -592,7 +592,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 3600s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -619,7 +619,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -668,7 +668,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -695,7 +695,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -722,7 +722,34 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
+      # Increasing the proxy buffer size
+      proxy_buffer_size 16k;
+      proxy_busy_buffers_size 16k;
+      rewrite ^/apis/(.*) /$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_pass http://ui-proxies:3003;
+    }
+
+    location ~ /apis/proxies/v8/ratings/v2/read {
+      # Enabling caching
+      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache ratings_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_methods POST;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 21600s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -749,7 +776,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -776,7 +803,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -803,7 +830,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -830,7 +857,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -857,7 +884,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -1357,6 +1384,16 @@ proxyconfig: |-
       proxy_read_timeout 70;
       proxy_http_version 1.1;
       proxy_pass http://ui-proxies:3003;
+    }
+
+    location = /api/v1/notifications/mandatory {
+      default_type application/json;
+      return 200 '{"id":"notification.v1.mandatory.current","ver":"1.0","params":{"err":null,"status":"success","errMsg":null},"responseCode":"OK","result":{"notification":{}},"response":{"notification":{}}}';
+    }
+
+    location = /apis/proxies/v8/v1/notifications/mandatory {
+      default_type application/json;
+      return 200 '{"id":"notification.v1.mandatory.current","ver":"1.0","params":{"err":null,"status":"success","errMsg":null},"responseCode":"OK","result":{"notification":{}},"response":{"notification":{}}}';
     }
 
     location /api/ {
@@ -4897,7 +4934,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -4951,7 +4988,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 300s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -4978,7 +5015,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 600s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -5005,7 +5042,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 600s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -6315,7 +6352,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 1800s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -6369,7 +6406,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 300s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -6396,7 +6433,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 600s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -6423,7 +6460,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 600s;
+      proxy_cache_valid 200 7200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;

--- a/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
+++ b/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
@@ -259,7 +259,7 @@ proxyconfig: |-
       proxy_pass http://ui-static;
     }
     # Caching for content consumption
-    location ~ /api/(content/v1/read|course/v1/hierarchy) {
+    location ~ /api/(content/v1/read|content/v2/read|course/v1/hierarchy) {
       # Enabling caching
       proxy_cache_key "$request_uri|$request_body";
       proxy_cache content_cache;
@@ -2539,7 +2539,7 @@ proxyconfig: |-
       proxy_pass http://ui-cbp-igot;
     }
     # Caching for content consumption
-    location ~ /api/(content/v1/read|course/v1/hierarchy) {
+    location ~ /api/(content/v1/read|content/v2/read|course/v1/hierarchy) {
       # Enabling caching
       proxy_cache_key "$request_uri|$request_body";
       proxy_cache content_cache;
@@ -3496,7 +3496,7 @@ proxyconfig: |-
       proxy_pass http://ui-cbp-igot;
     }
     # Caching for content consumption
-    location ~ /api/(content/v1/read|course/v1/hierarchy) {
+    location ~ /api/(content/v1/read|content/v2/read|course/v1/hierarchy) {
       # Enabling caching
       proxy_cache_key "$request_uri|$request_body";
       proxy_cache content_cache;
@@ -4494,7 +4494,7 @@ proxyconfig: |-
   }
 
     # Caching for content consumption
-    location ~ /api/(content/v1/read|course/v1/hierarchy) {
+    location ~ /api/(content/v1/read|content/v2/read|course/v1/hierarchy) {
       # Enabling caching
       proxy_cache_key "$request_uri|$request_body";
       proxy_cache content_cache;
@@ -4958,6 +4958,33 @@ proxyconfig: |-
       add_header X-Proxy-Cache-Date $upstream_http_date;
       proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
       proxy_cache_methods GET;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 14400s;
+      # Increasing the proxy buffer size
+      proxy_buffer_size 16k;
+      proxy_busy_buffers_size 16k;
+      rewrite ^/apis/(.*) /$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_pass http://ui-proxies:3003;
+    }
+
+    location ~ /apis/proxies/v8/(content/v2/read|course/v1/hierarchy) {
+      # Enabling caching
+      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache content_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_methods GET HEAD POST;
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
@@ -5912,7 +5939,7 @@ proxyconfig: |-
   }
 
     # Caching for content consumption
-    location ~ /api/(content/v1/read|course/v1/hierarchy) {
+    location ~ /api/(content/v1/read|content/v2/read|course/v1/hierarchy) {
       # Enabling caching
       proxy_cache_key "$request_uri|$request_body";
       proxy_cache content_cache;
@@ -6376,6 +6403,33 @@ proxyconfig: |-
       add_header X-Proxy-Cache-Date $upstream_http_date;
       proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
       proxy_cache_methods GET;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 14400s;
+      # Increasing the proxy buffer size
+      proxy_buffer_size 16k;
+      proxy_busy_buffers_size 16k;
+      rewrite ^/apis/(.*) /$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_pass http://ui-proxies:3003;
+    }
+
+    location ~ /apis/proxies/v8/(content/v2/read|course/v1/hierarchy) {
+      # Enabling caching
+      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache content_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_methods GET HEAD POST;
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
@@ -7458,7 +7512,7 @@ proxyconfig: |-
       proxy_pass http://ui-cbp-igot;
     }
     # Caching for content consumption
-    location ~ /api/(content/v1/read|course/v1/hierarchy) {
+    location ~ /api/(content/v1/read|content/v2/read|course/v1/hierarchy) {
       # Enabling caching
       proxy_cache_key "$request_uri|$request_body";
       proxy_cache content_cache;
@@ -8403,7 +8457,7 @@ proxyconfig: |-
       proxy_pass http://ui-cbp-igot;
     }
     # Caching for content consumption
-    location ~ /api/(content/v1/read|course/v1/hierarchy) {
+    location ~ /api/(content/v1/read|content/v2/read|course/v1/hierarchy) {
       # Enabling caching
       proxy_cache_key "$request_uri|$request_body";
       proxy_cache content_cache;

--- a/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
+++ b/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
@@ -1439,7 +1439,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 43200;
+      proxy_cache_valid 200 1800s;
       rewrite ^/apis/(.*) /$1 break;
       proxy_set_header Connection "";
       proxy_set_header Host $host;
@@ -2710,7 +2710,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 43200;
+      proxy_cache_valid 200 1800s;
       rewrite ^/apis/(.*) /$1 break;
       proxy_set_header Connection "";
       proxy_set_header Host $host;
@@ -3693,7 +3693,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 43200;
+      proxy_cache_valid 200 1800s;
       rewrite ^/apis/(.*) /$1 break;
       proxy_set_header Connection "";
       proxy_set_header Host $host;
@@ -5287,7 +5287,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 43200;
+      proxy_cache_valid 200 1800s;
       rewrite ^/apis/(.*) /$1 break;
       proxy_set_header Connection "";
       proxy_set_header Host $host;
@@ -6758,7 +6758,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 43200;
+      proxy_cache_valid 200 1800s;
       rewrite ^/apis/(.*) /$1 break;
       proxy_set_header Connection "";
       proxy_set_header Host $host;
@@ -7787,7 +7787,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 43200;
+      proxy_cache_valid 200 1800s;
       rewrite ^/apis/(.*) /$1 break;
       proxy_set_header Connection "";
       proxy_set_header Host $host;
@@ -8758,7 +8758,7 @@ proxyconfig: |-
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 43200;
+      proxy_cache_valid 200 1800s;
       rewrite ^/apis/(.*) /$1 break;
       proxy_set_header Connection "";
       proxy_set_header Host $host;

--- a/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
+++ b/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
@@ -209,6 +209,30 @@ proxyconfig: |-
       proxy_http_version 1.1;
       proxy_pass http://keycloak;
   }
+    # Caching keycloak certs endpoint
+    location ~ ^/auth/realms/([^/]+)/protocol/openid-connect/certs$ {
+      # Enabling caching
+      proxy_cache_key $proxy_host$request_uri;
+      proxy_cache proxy_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/auth/(.*) /auth/$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header    X-Forwarded-For   {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_pass http://keycloak;
+  }
     # This is Caching mechanism for POST requests location search
     location ~ /learner/data/v1/location/search {
       # Enabling caching
@@ -662,7 +686,7 @@ proxyconfig: |-
 
     location ~ /api/ratings/v1/summary/ {
       # Enabling caching
-      proxy_cache_key "$request_uri";
+      proxy_cache_key "$request_uri|$request_body";
       proxy_cache ratings_cache;
       add_header X-Proxy-Cache $upstream_cache_status;
       add_header X-Proxy-Cache-Date $upstream_http_date;
@@ -689,7 +713,7 @@ proxyconfig: |-
 
     location ~ /apis/proxies/v8/ratings/v1/summary {
       # Enabling caching
-      proxy_cache_key "$request_uri";
+      proxy_cache_key "$request_uri|$request_body";
       proxy_cache ratings_cache;
       add_header X-Proxy-Cache $upstream_cache_status;
       add_header X-Proxy-Cache-Date $upstream_http_date;
@@ -797,7 +821,7 @@ proxyconfig: |-
 
     location ~ /apis/proxies/sunbirdigot/read {
       # Enabling caching
-      proxy_cache_key "$request_uri";
+      proxy_cache_key "$request_uri|$request_body";
       proxy_cache ratings_cache;
       add_header X-Proxy-Cache $upstream_cache_status;
       add_header X-Proxy-Cache-Date $upstream_http_date;
@@ -915,33 +939,6 @@ proxyconfig: |-
       proxy_cache_background_update on;
       proxy_cache_lock on;
       proxy_cache_valid 200 14400s;
-      # Increasing the proxy buffer size
-      proxy_buffer_size 16k;
-      proxy_busy_buffers_size 16k;
-      rewrite ^/api/(.*) /$1 break;
-      proxy_set_header Connection "";
-      proxy_set_header Host $host;
-      proxy_set_header X-Scheme $scheme;
-      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
-      proxy_connect_timeout 5;
-      proxy_send_timeout 60;
-      proxy_read_timeout 70;
-      proxy_http_version 1.1;
-      proxy_pass http://kong;
-    }
-
-    location ~ /api/faq/v1/assistant/configs/language {
-      # Enabling caching
-      proxy_cache_key "$request_uri";
-      proxy_cache sunbirdigot_cache;
-      add_header X-Proxy-Cache $upstream_cache_status;
-      add_header X-Proxy-Cache-Date $upstream_http_date;
-      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-      proxy_cache_methods GET;
-      proxy_cache_revalidate on;
-      proxy_cache_background_update on;
-      proxy_cache_lock on;
-      proxy_cache_valid 200 43200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -1229,16 +1226,16 @@ proxyconfig: |-
 
     location ~ /api/faq/v1/assistant/configs/language {
       # Enabling caching
-      proxy_cache_key "$request_uri|$request_body";
+      proxy_cache_key "$request_method|$request_uri|$request_body";
       proxy_cache sunbirdigot_cache;
       add_header X-Proxy-Cache $upstream_cache_status;
       add_header X-Proxy-Cache-Date $upstream_http_date;
       proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
-      proxy_cache_methods POST;
+      proxy_cache_methods GET HEAD POST;
       proxy_cache_revalidate on;
       proxy_cache_background_update on;
       proxy_cache_lock on;
-      proxy_cache_valid 200 86400s;
+      proxy_cache_valid 200 43200s;
       # Increasing the proxy buffer size
       proxy_buffer_size 16k;
       proxy_busy_buffers_size 16k;
@@ -2455,6 +2452,30 @@ proxyconfig: |-
       proxy_http_version 1.1;
       proxy_pass http://keycloak;
   }
+    # Caching keycloak certs endpoint
+    location ~ ^/auth/realms/([^/]+)/protocol/openid-connect/certs$ {
+      # Enabling caching
+      proxy_cache_key $proxy_host$request_uri;
+      proxy_cache proxy_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/auth/(.*) /auth/$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header    X-Forwarded-For   {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_pass http://keycloak;
+  }
     # This is Caching mechanism for POST requests location search
     location ~ /learner/data/v1/location/search {
       # Enabling caching
@@ -3366,6 +3387,30 @@ proxyconfig: |-
     }
     # Caching keycloak static assets
     location ~ /auth/resources/(.+\.(png|jpg|svg|ico|js|eot|ttf|woff|woff2|css)) {
+      # Enabling caching
+      proxy_cache_key $proxy_host$request_uri;
+      proxy_cache proxy_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/auth/(.*) /auth/$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header    X-Forwarded-For   {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_pass http://keycloak;
+  }
+    # Caching keycloak certs endpoint
+    location ~ ^/auth/realms/([^/]+)/protocol/openid-connect/certs$ {
       # Enabling caching
       proxy_cache_key $proxy_host$request_uri;
       proxy_cache proxy_cache;
@@ -4364,6 +4409,30 @@ proxyconfig: |-
     }
     # Caching keycloak static assets
     location ~ /auth/resources/(.+\.(png|svg|ico|js|eot|ttf|woff|woff2|css)) {
+      # Enabling caching
+      proxy_cache_key $proxy_host$request_uri;
+      proxy_cache proxy_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/auth/(.*) /auth/$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header    X-Forwarded-For   {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_pass http://keycloak;
+  }
+    # Caching keycloak certs endpoint
+    location ~ ^/auth/realms/([^/]+)/protocol/openid-connect/certs$ {
       # Enabling caching
       proxy_cache_key $proxy_host$request_uri;
       proxy_cache proxy_cache;
@@ -5758,6 +5827,30 @@ proxyconfig: |-
 
     # Caching keycloak static assets
     location ~ /auth/resources/(.+\.(png|svg|ico|js|eot|ttf|woff|woff2|css)) {
+      # Enabling caching
+      proxy_cache_key $proxy_host$request_uri;
+      proxy_cache proxy_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/auth/(.*) /auth/$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header    X-Forwarded-For   {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_pass http://keycloak;
+  }
+    # Caching keycloak certs endpoint
+    location ~ ^/auth/realms/([^/]+)/protocol/openid-connect/certs$ {
       # Enabling caching
       proxy_cache_key $proxy_host$request_uri;
       proxy_cache proxy_cache;
@@ -7278,6 +7371,30 @@ proxyconfig: |-
       proxy_http_version 1.1;
       proxy_pass http://keycloak;
   }
+    # Caching keycloak certs endpoint
+    location ~ ^/auth/realms/([^/]+)/protocol/openid-connect/certs$ {
+      # Enabling caching
+      proxy_cache_key $proxy_host$request_uri;
+      proxy_cache proxy_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/auth/(.*) /auth/$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header    X-Forwarded-For   {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_pass http://keycloak;
+  }
     # This is Caching mechanism for POST requests location search
     location ~ /learner/data/v1/location/search {
       # Enabling caching
@@ -8177,6 +8294,30 @@ proxyconfig: |-
     }
     # Caching keycloak static assets
     location ~ /auth/resources/(.+\.(png|jpg|svg|ico|js|eot|ttf|woff|woff2|css)) {
+      # Enabling caching
+      proxy_cache_key $proxy_host$request_uri;
+      proxy_cache proxy_cache;
+      add_header X-Proxy-Cache $upstream_cache_status;
+      add_header X-Proxy-Cache-Date $upstream_http_date;
+      proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+      proxy_cache_revalidate on;
+      proxy_cache_background_update on;
+      proxy_cache_lock on;
+      proxy_cache_valid 200 43200;
+      rewrite ^/auth/(.*) /auth/$1 break;
+      proxy_set_header Connection "";
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_set_header X-Scheme $scheme;
+      proxy_set_header    X-Forwarded-For   {{ nginx_client_public_ip_header | d('$remote_addr') }};
+      proxy_connect_timeout 5;
+      proxy_send_timeout 60;
+      proxy_read_timeout 70;
+      proxy_http_version 1.1;
+      proxy_pass http://keycloak;
+  }
+    # Caching keycloak certs endpoint
+    location ~ ^/auth/realms/([^/]+)/protocol/openid-connect/certs$ {
       # Enabling caching
       proxy_cache_key $proxy_host$request_uri;
       proxy_cache proxy_cache;
@@ -9175,16 +9316,12 @@ nginxconfig: |
       # inactive: specifies how long an item can remain in the cache without being accessed. This doesn't value expiry time of cache. So keep it more than the expiry.
       # use_temp_path: do we have to write the cache to a temp path first? This will reduce the performance.
       #
-      # caching for images and files
-      proxy_cache_path /tmp/proxy_cache levels=1:2 keys_zone=tmp_cache:5m max_size=10m inactive=300m use_temp_path=off;
       # caching for apis
       proxy_cache_path /tmp/api_cache levels=1:2 keys_zone=proxy_cache:5m max_size=600m inactive=1400m use_temp_path=off;
       # cache framework
       proxy_cache_path /tmp/framework_cache levels=1:2 keys_zone=framework_cache:5m max_size=700m inactive=300m use_temp_path=off;
       # cache content
       proxy_cache_path /tmp/content_cache levels=1:2 keys_zone=content_cache:100m max_size=3000m inactive=600m use_temp_path=off;
-      # cache content metadata
-      proxy_cache_path /tmp/content_metadata levels=1:2 keys_zone=content_metadata:100m max_size=1000m inactive=300m use_temp_path=off;
       proxy_cache_path /tmp/ratings_cache levels=1:2 keys_zone=ratings_cache:100m max_size=3000m inactive=600m use_temp_path=off;
       proxy_cache_path /tmp/sunbirdigot_cache levels=1:2 keys_zone=sunbirdigot_cache:100m max_size=3000m inactive=600m use_temp_path=off;
 

--- a/kubernetes/helm_charts/igot-deploy/ui-proxies/templates/deployment.yaml
+++ b/kubernetes/helm_charts/igot-deploy/ui-proxies/templates/deployment.yaml
@@ -36,8 +36,8 @@ spec:
                 - -c
                 - sleep 10
         env:
-        - name: JAVA_OPTIONS
-          value: {{ .Values.env.javaoptions | quote }}
+        - name: NODE_OPTIONS
+          value: {{ .Values.env.nodeoptions | quote }}
         envFrom:
         - configMapRef:
             name: {{ .Chart.Name }}-config

--- a/kubernetes/helm_charts/igot-deploy/ui-proxies/values.j2
+++ b/kubernetes/helm_charts/igot-deploy/ui-proxies/values.j2
@@ -6,7 +6,7 @@ dockerhub: {{ docker_hub_url }}
 
 
 env:
-  javaoptions: {{ui_proxies_java_mem_limit|default('-Xmx600m')}}
+  nodeoptions: {{ui_proxies_node_mem_limit|default('-Xmx600m')}}
 
 replicaCount: {{ui_proxies_replicacount|default(1)}}
 repository: {{ image_ui_proxies }}


### PR DESCRIPTION
## Summary
This PR updates the nginx public ingress cache strategy to reduce repeated backend calls on high-traffic APIs and improve cache hit rate consistency across commonly accessed endpoints.
It adds caching for the Keycloak certs endpoint, extends TTLs for several existing cached routes, updates cache keys for body-dependent APIs, and adds static handling for mandatory notification endpoints to avoid unnecessary upstream traffic.
## Nginx cache changes
### New cached path
- `/auth/realms/<realm>/protocol/openid-connect/certs`
  - Added nginx caching for Keycloak certs endpoint
  - Cache key: `$proxy_host$request_uri`
  - TTL: `43200s` (12h)
  - Uses stale cache on upstream errors/timeouts
  - Enables revalidation, background update, and cache locking
- `/api/content/v2/read`
  - Added to the existing `content_cache` content-consumption rule
  - Cache key: `$request_uri|$request_body`
  - Cache methods: `GET HEAD POST`
  - TTL: `14400s`
- `/apis/proxies/v8/content/v2/read`
  - Added new cached nginx route for proxied content read
  - Cache key: `$request_uri|$request_body`
  - Cache methods: `GET HEAD POST`
  - TTL: `14400s`
  - Proxied to `ui-proxies:3003`
- `/api/course/v1/hierarchy`
  - Confirmed in the existing `content_cache` rule
- `/apis/proxies/v8/course/v1/hierarchy`
  - Added new cached nginx route for proxied course hierarchy
  - Cache key: `$request_uri|$request_body`
  - Cache methods: `GET HEAD POST`
  - TTL: `14400s`
  - Proxied to `ui-proxies:3003`
- `/apis/v1/form/read`
  - Added dedicated nginx caching similar to the existing `form/read` cache rule
  - Cache key: `$request_uri|$request_body`
  - Cache methods: `GET HEAD POST`
  - TTL: `43200`
  - Routed via `ui-proxies:3003`
### TTL increased to 7200s
- `/learner/data/v1/location/search`
  - TTL changed from `1800s` to `7200s`
- `/api/ratings/v1/summary/`
  - Cache key changed from `$request_uri` to `$request_uri|$request_body`
  - TTL changed from `1800s` to `7200s`
- `/apis/proxies/v8/ratings/v1/summary`
  - Cache key changed from `$request_uri` to `$request_uri|$request_body`
  - TTL changed from `1800s` to `7200s`
- `/apis/proxies/v8/sunbirdigot/v4/search`
  - Cache key changed from `$request_uri` to `$request_uri|$request_body`
  - Cache method set to `POST`
  - TTL changed from `1800s` to `7200s`
- `/apis/public/v8/careers/list`
  - TTL changed from `1800s` to `7200s`
- `/apis/public/v8/tenders/list`
  - TTL changed from `1800s` to `7200s`
- `/apis/proxies/sunbirdigot/read`
  - TTL changed from `1800s` to `7200s`
- `/apis/proxies/sunbirdigot/search`
  - Cache key changed from `$request_uri` to `$request_uri|$request_body`
  - Cache method set to `POST`
  - TTL changed from `1800s` to `7200s`
### TTL increased to 21600s
- `/apis/proxies/v8/ratings/v2/read`
  - New dedicated cached route in this config block
  - Cache key: `$request_uri|$request_body`
  - TTL: `21600s` (6h)
### TTL adjusted for Sunbird iGOT endpoints
- `/api/user/v1/positions`
  - Existing caching retained
  - TTL remains `14400s` in this block, route placement updated in config
- `/apis/protected/v8/user/profileRegistry/getMasterLanguages`
  - Existing caching retained, route placement updated in config
- `/api/masterData/v1/getLanguages`
  - TTL changed from `43200s` to `14400s`
### FAQ assistant language config cache update
- `/api/faq/v1/assistant/configs/language`
  - Cache key changed from `$request_uri|$request_body` to `$request_method|$request_uri|$request_body`
  - Cache methods changed from `POST` to `GET HEAD POST`
  - TTL changed from `86400s` to `43200s`
### Static no-upstream response added
- `/api/v1/notifications/mandatory`
- `/apis/proxies/v8/v1/notifications/mandatory`
  - Added direct nginx `200` JSON response
  - Avoids upstream call entirely for this endpoint
## Cache zone/config cleanup
- Removed unused cache path:
  - `/tmp/proxy_cache` (`tmp_cache`)
- Removed unused cache path:
  - `/tmp/content_metadata` (`content_metadata`)
## Additional non-nginx changes in this PR
- Increased default Helm install timeout from `10m` to `20m` across multiple Ansible roles
- Added configurable object-memory sizing for Keycloak distributed caches
- Updated Keycloak node identifiers to use hostname-based values instead of IP-based values
- Changed `ui-proxies` env var from `JAVA_OPTIONS` to `NODE_OPTIONS`