### PR TITLE
KB-14311 added new API for chatbot insight

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -25223,3 +25223,21 @@ kong_apis:
         config.limit_by: credential
       - name: request-size-limiting
         config.allowed_payload_size: "{{ medium_request_size_limit }}"
+
+  - name: chatbotInsights
+    uris: "/chatbot/v2/insights"
+    upstream_url: "{{ sb_cb_ext_service_url }}/chatbot/v2/insights"
+    strip_uri: true
+    plugins:
+      - name: jwt
+      - name: cors
+      - "{{ statsd_pulgin }}"
+      - name: acl
+        config.whitelist:
+          - 'dataAccess'
+      - name: rate-limiting
+        config.policy: local
+        config.hour: "{{ medium_rate_limit_per_hour }}"
+        config.limit_by: credential
+      - name: request-size-limiting
+        config.allowed_payload_size: "{{ medium_request_size_limit }}"


### PR DESCRIPTION
Create new API endpoint which returns 12 weeks of weekly claps data - To be used only for chatbot