### PR TITLE
KB-15114 | BE | DEV | Implementation of the Kong and UI proxy entriesfor the Training Plan APIs

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -26640,3 +26640,129 @@ kong_apis:
         config.limit_by: credential
       - name: request-size-limiting
         config.allowed_payload_size: "{{ medium_request_size_limit }}"      
+
+  - name: cbPlanV3Create
+    uris: "{{ cb_plan_prefix }}/v3/create"
+    upstream_url: "{{ cb_ext_course_service_url }}/cbplan/v3/create"
+    strip_uri: true
+    plugins:
+      - name: jwt
+      - name: cors
+      - "{{ statsd_pulgin }}"
+      - name: acl
+        config.whitelist:
+          - 'dataCreate'
+      - name: rate-limiting
+        config.policy: local
+        config.hour: "{{ medium_rate_limit_per_hour }}"
+        config.limit_by: credential
+      - name: request-size-limiting
+        config.allowed_payload_size: "{{ small_request_size_limit }}"
+
+  - name: cbPlanV3Update
+    uris: "{{ cb_plan_prefix }}/v3/update"
+    upstream_url: "{{ cb_ext_course_service_url }}/cbplan/v3/update"
+    strip_uri: true
+    plugins:
+      - name: jwt
+      - name: cors
+      - "{{ statsd_pulgin }}"
+      - name: acl
+        config.whitelist:
+          - 'dataCreate'
+      - name: rate-limiting
+        config.policy: local
+        config.hour: "{{ medium_rate_limit_per_hour }}"
+        config.limit_by: credential
+      - name: request-size-limiting
+        config.allowed_payload_size: "{{ small_request_size_limit }}"
+
+  - name: cbPlanV3Publish
+    uris: "{{ cb_plan_prefix }}/v3/publish"
+    upstream_url: "{{ cb_ext_course_service_url }}/cbplan/v3/publish"
+    strip_uri: true
+    plugins:
+      - name: jwt
+      - name: cors
+      - "{{ statsd_pulgin }}"
+      - name: acl
+        config.whitelist:
+          - 'dataCreate'
+      - name: rate-limiting
+        config.policy: local
+        config.hour: "{{ medium_rate_limit_per_hour }}"
+        config.limit_by: credential
+      - name: request-size-limiting
+        config.allowed_payload_size: "{{ small_request_size_limit }}"
+
+  - name: cbPlanV3Archive
+    uris: "{{ cb_plan_prefix }}/v3/archive"
+    upstream_url: "{{ cb_ext_course_service_url }}/cbplan/v3/archive"
+    strip_uri: true
+    plugins:
+      - name: jwt
+      - name: cors
+      - "{{ statsd_pulgin }}"
+      - name: acl
+        config.whitelist:
+          - 'dataCreate'
+      - name: rate-limiting
+        config.policy: local
+        config.hour: "{{ medium_rate_limit_per_hour }}"
+        config.limit_by: credential
+      - name: request-size-limiting
+        config.allowed_payload_size: "{{ small_request_size_limit }}"
+
+  - name: cbPlanV3ReadById
+    uris: "{{ cb_plan_prefix }}/v3/read"
+    upstream_url: "{{ cb_ext_course_service_url }}/cbplan/v3/read"
+    strip_uri: true
+    plugins:
+      - name: jwt
+      - name: cors
+      - "{{ statsd_pulgin }}"
+      - name: acl
+        config.whitelist:
+          - 'dataAccess'
+      - name: rate-limiting
+        config.policy: local
+        config.hour: "{{ medium_rate_limit_per_hour }}"
+        config.limit_by: credential
+      - name: request-size-limiting
+        config.allowed_payload_size: "{{ small_request_size_limit }}"
+
+  - name: cbPlanV3Search
+    uris: "{{ cb_plan_prefix }}/v3/search"
+    upstream_url: "{{ cb_ext_course_service_url }}/cbplan/v3/search"
+    strip_uri: true
+    plugins:
+      - name: jwt
+      - name: cors
+      - "{{ statsd_pulgin }}"
+      - name: acl
+        config.whitelist:
+          - 'dataCreate'
+      - name: rate-limiting
+        config.policy: local
+        config.hour: "{{ medium_rate_limit_per_hour }}"
+        config.limit_by: credential
+      - name: request-size-limiting
+        config.allowed_payload_size: "{{ small_request_size_limit }}"
+
+  - name: cbPlanV3UserDictionary
+    uris: "{{ cb_plan_prefix }}/v3/user/dictionary"
+    upstream_url: "{{ cb_ext_course_service_url }}/cbplan/v3/user/dictionary"
+    strip_uri: true
+    plugins:
+      - name: jwt
+      - name: cors
+      - "{{ statsd_pulgin }}"
+      - name: acl
+        config.whitelist:
+          - 'dataAccess'
+      - name: rate-limiting
+        config.policy: local
+        config.hour: "{{ medium_rate_limit_per_hour }}"
+        config.limit_by: credential
+      - name: request-size-limiting
+        config.allowed_payload_size: "{{ small_request_size_limit }}"


### PR DESCRIPTION
Add Kong API entries for /cbplan/v3 endpoints
Register the seven CbPlanWithAccessSettingsV3 endpoints in kong_apis, routing /cbplan/v3/* to cb_ext_course_service_url. Entries mirror the existing /cbplan/v2 block key for key: jwt, cors, statsd, acl, rate-limiting and request-size-limiting plugins with strip_uri enabled. Endpoints: create, update, publish, archive, read, search and user/dictionary. Write and search routes use the dataCreate ACL group; read and user/dictionary use dataAccess, matching v2. Read-by-id relies on the existing strip_uri prefix-match convention so the {cbPlanId} path segment is forwarded upstream.
